### PR TITLE
added api for mobile usage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,3 +64,6 @@ gem 'capistrano-rvm'
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+# enable CORS for api
+gem 'rack-cors', :require => 'rack/cors'

--- a/app/controllers/admin/admin_users_controller.rb
+++ b/app/controllers/admin/admin_users_controller.rb
@@ -10,8 +10,8 @@ class Admin::AdminUsersController < Admin::AdminController
 	end
 
 	def show
-		user_name = AdminUser.find_by_id(params[:id]).username
-		@page_title = "#{user_name} | Kicks4Love Admin"
+		@api_key = @admin_user.api_key || ''
+		@page_title = "#{@admin_user.username} | Kicks4Love Admin"
 	end
 
 	def destroy

--- a/app/controllers/admin/admin_users_controller.rb
+++ b/app/controllers/admin/admin_users_controller.rb
@@ -10,7 +10,7 @@ class Admin::AdminUsersController < Admin::AdminController
 	end
 
 	def show
-		@api_key = @admin_user.api_key || ''
+		@api_key = @admin_user.api_key.present? ? @admin_user.api_key.access_token : ''
 		@page_title = "#{@admin_user.username} | Kicks4Love Admin"
 	end
 
@@ -30,7 +30,7 @@ class Admin::AdminUsersController < Admin::AdminController
 			end
 			return
 		end
-			
+
 		redirect_to :back, :alert => 'Unable to destroy the admin user: ' << @admin_user.errors[:base].to_s
 	end
 

--- a/app/controllers/admin/registrations_controller.rb
+++ b/app/controllers/admin/registrations_controller.rb
@@ -15,12 +15,33 @@ class Admin::RegistrationsController < Devise::RegistrationsController
 	    end
 	end
 
+	def create
+		super do |resource|
+			Rails.logger.debug params[:set_api_key]
+			if params[:set_api_key]
+				resource.api_key = ApiKey.create
+			end
+		end
+	end
+
+	def update
+		super do |resource|
+			Rails.logger.debug params[:set_api_key]
+			if params[:set_api_key]
+				if resource.api_key.present?
+					resource.api_key.delete
+				end
+				resource.api_key = ApiKey.create
+			end
+		end
+	end
+
 	def sign_up_params
-		params.require(:admin_user).permit(:username, :email, :password, :password_confirmation)
+		params.require(:admin_user).permit(:username, :email, :password, :password_confirmation, :set_api_key)
 	end
 
 	def account_update_params
-		params.require(:admin_user).permit(:username, :email, :password, :password_confirmation, :current_password)
+		params.require(:admin_user).permit(:username, :email, :password, :password_confirmation, :current_password, :set_api_key)
 	end
 
 	protected

--- a/app/controllers/api/api_base_controller.rb
+++ b/app/controllers/api/api_base_controller.rb
@@ -30,30 +30,9 @@ class Api::ApiBaseController < ApplicationController
 
   def search
     query = params[:q].present? ? params[:q].strip : '*'
-    query = {
-			query: {
-                multi_match: {
-                    query: params[:q].present? ? params[:q].strip : '*',
-                    type:  'best_fields',
-                    fields: ['title_en^10', 'title_cn^10', 'content_cn', 'content_en'],
-                    operator: 'or',
-                    zero_terms_query: 'all'
-                }
-            }, highlight: { fields: {:'*' => {}} }
-        }
-    results = Elasticsearch::Model
-    .search(
-    query,
-    [FeaturePost,
-      OnCourtPost,
-      TrendPost,
-      CalendarPost,
-      StreetSnapPost,
-      RumorPost]).page(params[:page] || 1).per_page(10).results
-
-    no_more = results.total_pages <= results.current_page
-
-    render json: {no_more: no_more, results: Api::ApiHelper.reformat_search_results(results, root_url.chop)}.to_json, status: :ok
+    results = Elasticsearch::Model.search(query).page(params[:page] || 1).per_page(10).records
+    no_more = results.current_page >= results.total_pages
+    render json: { no_more: no_more, results: Api::ApiHelper.reformat_search_results(results, root_url.chop) }.to_json, status: :ok
 
   end
 

--- a/app/controllers/api/api_base_controller.rb
+++ b/app/controllers/api/api_base_controller.rb
@@ -29,8 +29,20 @@ class Api::ApiBaseController < ApplicationController
   end
 
   def search
-    query = params[:q].present? ? params[:q].strip : '*'
-    results = Elasticsearch::Model.search(query).page(params[:page] || 1).per_page(10).records
+    query = {
+      query: {
+        multi_match: {
+          query: params[:q].present? ? params[:q].strip : '*',
+          type:  'best_fields',
+          fields: ['title_en^10', 'title_cn^10', 'content_cn', 'content_en']
+        }
+      }
+    }
+    results = Elasticsearch::Model
+      .search(query, [FeaturePost, OnCourtPost, TrendPost, CalendarPost, StreetSnapPost, RumorPost])
+      .page(params[:page] || 1)
+      .per_page(10)
+      .records
     no_more = results.current_page >= results.total_pages
     render json: { no_more: no_more, results: Api::ApiHelper.reformat_search_results(results, root_url.chop) }.to_json, status: :ok
 

--- a/app/controllers/api/api_base_controller.rb
+++ b/app/controllers/api/api_base_controller.rb
@@ -1,7 +1,7 @@
 class Api::ApiBaseController < ApplicationController
 
   protect_from_forgery with: :null_session
-  before_action :set_lang # TODO: check auth key before every request
+  before_action :set_lang, :check_key # TODO: check auth key before every request
 
   VALID_POST_TYPES =
   ['FeaturePost', 'OnCourtPost', 'TrendPost', 'StreetSnapPost', 'RumorPost']
@@ -51,6 +51,12 @@ class Api::ApiBaseController < ApplicationController
   private
   def set_lang
     @chinese = params[:l] == 'cn'
+  end
+
+  def check_key
+    authenticate_or_request_with_http_token do |token, options|
+      ApiKey.exists?(access_token: token)
+    end
   end
 
 end

--- a/app/controllers/api/api_base_controller.rb
+++ b/app/controllers/api/api_base_controller.rb
@@ -15,7 +15,8 @@ class Api::ApiBaseController < ApplicationController
                 }
             }, highlight: { fields: {:'*' => {}} }
         }
-		results = Elasticsearch::Model.search(
+    results = Elasticsearch::Model
+    .search(
     query,
     [FeaturePost,
       OnCourtPost,
@@ -23,8 +24,10 @@ class Api::ApiBaseController < ApplicationController
       CalendarPost,
       StreetSnapPost,
       RumorPost]).page(params[:page] || 1).per_page(10).results
+    
+    no_more = results.total_pages <= results.current_page
 
-    render json: {results: Api::ApiHelper.reformat_search_results(results, root_url.chop)}.to_json, status: :ok
+    render json: {no_more: no_more, results: Api::ApiHelper.reformat_search_results(results, root_url.chop)}.to_json, status: :ok
 
   end
 

--- a/app/controllers/api/api_base_controller.rb
+++ b/app/controllers/api/api_base_controller.rb
@@ -3,9 +3,7 @@ class Api::ApiBaseController < ApplicationController
   protect_from_forgery with: :null_session
   before_action :set_lang, :authenticate_request
 
-  VALID_POST_TYPES =
-  ['FeaturePost', 'OnCourtPost', 'TrendPost', 'StreetSnapPost', 'RumorPost']
-
+  VALID_POST_TYPES = ['FeaturePost', 'OnCourtPost', 'TrendPost', 'StreetSnapPost', 'RumorPost']
 
   def rate
     score = count = 0
@@ -21,11 +19,9 @@ class Api::ApiBaseController < ApplicationController
       rescue => error
         render :json => { :message => error.message }.to_json, :status => 400
       end
-
     else
       render :json => { :message => 'argument not right' }.to_json, :status => 422
     end
-
   end
 
   def search
@@ -38,17 +34,13 @@ class Api::ApiBaseController < ApplicationController
         }
       }
     }
-    results = Elasticsearch::Model
-      .search(query, [FeaturePost, OnCourtPost, TrendPost, CalendarPost, StreetSnapPost, RumorPost])
-      .page(params[:page] || 1)
-      .per_page(10)
-      .records
+    results = Elasticsearch::Model.search(query, [FeaturePost, OnCourtPost, TrendPost, CalendarPost, StreetSnapPost, RumorPost]).page(params[:page] || 1).per_page(10).records
     no_more = results.current_page >= results.total_pages
     render json: { no_more: no_more, results: Api::ApiHelper.reformat_search_results(results, root_url.chop) }.to_json, status: :ok
-
   end
 
   private
+
   def set_lang
     @chinese = params[:l] == 'cn'
   end

--- a/app/controllers/api/api_base_controller.rb
+++ b/app/controllers/api/api_base_controller.rb
@@ -1,0 +1,9 @@
+class Api::ApiBaseController < ApplicationController
+
+  before_action :set_lang
+
+  def set_lang
+    @chinese = params[:l] == 'cn'
+  end
+
+end

--- a/app/controllers/api/api_base_controller.rb
+++ b/app/controllers/api/api_base_controller.rb
@@ -3,6 +3,10 @@ class Api::ApiBaseController < ApplicationController
   protect_from_forgery with: :null_session
   before_action :set_lang, :authenticate_request
 
+  rescue_from StandardError do |exception|
+    render json: { message: exception }.to_json, status: :internal_server_error
+  end
+
   VALID_POST_TYPES = ['FeaturePost', 'OnCourtPost', 'TrendPost', 'StreetSnapPost', 'RumorPost']
 
   def rate
@@ -42,7 +46,7 @@ class Api::ApiBaseController < ApplicationController
   private
 
   def set_lang
-    @chinese = params[:l] == 'cn'
+    @chinese = params[:l] == 'zh'
   end
 
   def authenticate_request

--- a/app/controllers/api/api_base_controller.rb
+++ b/app/controllers/api/api_base_controller.rb
@@ -43,6 +43,22 @@ class Api::ApiBaseController < ApplicationController
     render json: { no_more: no_more, results: Api::ApiHelper.reformat_search_results(@chinese, results, root_url.chop) }.to_json, status: :ok
   end
 
+  def email
+    begin
+      email_options = {
+        :first_name => params[:first_name],
+        :last_name => params[:last_name],
+        :chinese => @chinese,
+        :comment => params[:comments]
+      }
+      CustomerServiceMailer.send_contact_email(params[:email], email_options).deliver_now
+      render json: { message: "Successfully sent email"}, status: :ok
+    rescue
+      message = @chinese ? "发送您的信息时发生了错误，请重试一遍" : "Error occurs while sending your message, please try again"
+      render json: { message: message }, status: 400
+    end
+  end
+
   private
 
   def set_lang

--- a/app/controllers/api/api_base_controller.rb
+++ b/app/controllers/api/api_base_controller.rb
@@ -1,7 +1,34 @@
 class Api::ApiBaseController < ApplicationController
 
-  before_action :set_lang
+  before_action :set_lang # TODO: check auth key before every request
 
+  def search
+    query = params[:q].present? ? params[:q].strip : '*'
+    query = {
+			query: {
+                multi_match: {
+                    query: params[:q].present? ? params[:q].strip : '*',
+                    type:  'best_fields',
+                    fields: ['title_en^10', 'title_cn^10', 'content_cn', 'content_en'],
+                    operator: 'or',
+                    zero_terms_query: 'all'
+                }
+            }, highlight: { fields: {:'*' => {}} }
+        }
+		results = Elasticsearch::Model.search(
+    query,
+    [FeaturePost,
+      OnCourtPost,
+      TrendPost,
+      CalendarPost,
+      StreetSnapPost,
+      RumorPost]).page(params[:page] || 1).per_page(10).results
+
+    render json: {results: Api::ApiHelper.reformat_search_results(results, root_url.chop)}.to_json, status: :ok
+
+  end
+
+  private
   def set_lang
     @chinese = params[:l] == 'cn'
   end

--- a/app/controllers/api/api_base_controller.rb
+++ b/app/controllers/api/api_base_controller.rb
@@ -40,7 +40,7 @@ class Api::ApiBaseController < ApplicationController
     }
     results = Elasticsearch::Model.search(query, [FeaturePost, OnCourtPost, TrendPost, CalendarPost, StreetSnapPost, RumorPost]).page(params[:page] || 1).per_page(10).records
     no_more = results.current_page >= results.total_pages
-    render json: { no_more: no_more, results: Api::ApiHelper.reformat_search_results(results, root_url.chop) }.to_json, status: :ok
+    render json: { no_more: no_more, results: Api::ApiHelper.reformat_search_results(@chinese, results, root_url.chop) }.to_json, status: :ok
   end
 
   private

--- a/app/controllers/api/calendar_posts_controller.rb
+++ b/app/controllers/api/calendar_posts_controller.rb
@@ -2,6 +2,7 @@ class Api::CalendarPostsController < Api::ApiBaseController
 
   def index
     @return_posts = []
+
     if params[:year].present? && params[:month].present?
       feeds = CalendarPost.where('extract(year from release_date) = ? AND extract(month from release_date) = ?', params[:year], params[:month])
       if @chinese
@@ -11,6 +12,7 @@ class Api::CalendarPostsController < Api::ApiBaseController
       end
       @return_posts = Api::ApiHelper.reformat_feeds(feeds, root_url.chop)
     end
+
     render json: { posts: @return_posts }.to_json, status: :ok
   end
 

--- a/app/controllers/api/calendar_posts_controller.rb
+++ b/app/controllers/api/calendar_posts_controller.rb
@@ -1,0 +1,17 @@
+class Api::CalendarPostsController < Api::ApiBaseController
+
+  def index
+    @return_posts = []
+    if params[:year].present? && params[:month].present?
+      feeds = CalendarPost.where('extract(year from release_date) = ? AND extract(month from release_date) = ?', params[:year], params[:month])
+      if @chinese
+        feeds = feeds.select("id, title_cn AS title, release_date, release_type, rmb AS price, cover_image")
+      else
+        feeds = feeds.select("id, title_en AS title, release_date, release_type, usd AS price, cover_image")
+      end
+      @return_posts = Api::ApiHelper.reformat_feeds(feeds, root_url.chop)
+    end
+    render json: { posts: @return_posts }.to_json, status: :ok
+  end
+
+end

--- a/app/controllers/api/featured_posts_controller.rb
+++ b/app/controllers/api/featured_posts_controller.rb
@@ -22,7 +22,8 @@ class Api::FeaturedPostsController < Api::ApiBaseController
   def show
     begin
       post = FeaturePost.find(params[:id])
-      render json: { post: post }.to_json, status: :ok
+      return_post = Api::ApiHelper.format_post(post, root_url.chop)
+      render json: return_post.to_json, status: :ok
     rescue ActiveRecord::RecordNotFound => e
       render json: { message: e.message }.to_json, status: :not_found
     end

--- a/app/controllers/api/featured_posts_controller.rb
+++ b/app/controllers/api/featured_posts_controller.rb
@@ -2,6 +2,7 @@ class Api::FeaturedPostsController < Api::ApiBaseController
 
   def index
     @return_posts = []
+
     if params[:next_page].present?
       feeds = FeaturePost.paginate(:page => params[:next_page], :per_page => 6).latest
       logger.debug "total: " + feeds.total_pages.to_s + " current: " + feeds.current_page.to_s
@@ -18,8 +19,8 @@ class Api::FeaturedPostsController < Api::ApiBaseController
     else
       @no_more = true
     end
-    render json: Api::ApiHelper.json_response(@no_more, @return_posts), status: :ok
 
+    render json: Api::ApiHelper.json_response(@no_more, @return_posts), status: :ok
   end
 
   def show

--- a/app/controllers/api/featured_posts_controller.rb
+++ b/app/controllers/api/featured_posts_controller.rb
@@ -8,9 +8,9 @@ class Api::FeaturedPostsController < Api::ApiBaseController
       @no_more = feeds.total_pages <= feeds.current_page
       unless feeds.blank?
         if @chinese
-          feeds = feeds.select("id, title_cn AS title, content_cn AS content, cover_image, created_at")
+          feeds = feeds.select("id, title_cn AS title, content_cn AS content, cover_image, created_at, author_id")
         else
-          feeds = feeds.select("id, title_en AS title, content_en AS content, cover_image, created_at")
+          feeds = feeds.select("id, title_en AS title, content_en AS content, cover_image, created_at, author_id")
         end
         feeds.each {|feed| feed.content = feed.content.blank? ? "" : YAML.load(feed.content)}
         @return_posts = Api::ApiHelper.reformat_feeds(feeds, root_url.chop, false)

--- a/app/controllers/api/featured_posts_controller.rb
+++ b/app/controllers/api/featured_posts_controller.rb
@@ -1,19 +1,22 @@
 class Api::FeaturedPostsController < Api::ApiBaseController
 
   def index
+    @return_posts = []
     if params[:next_page].present?
       feeds = FeaturePost.paginate(:page => params[:next_page], :per_page => 6).latest
-      @no_more = feeds.total_pages == feeds.current_page
-      if @chinese
-        feeds = feeds.select("id, title_cn AS title, content_cn AS content, cover_image, created_at")
-      else
-        feeds = feeds.select("id, title_en AS title, content_en AS content, cover_image, created_at")
+      logger.debug "total: " + feeds.total_pages.to_s + " current: " + feeds.current_page.to_s
+      @no_more = feeds.total_pages <= feeds.current_page
+      unless feeds.blank?
+        if @chinese
+          feeds = feeds.select("id, title_cn AS title, content_cn AS content, cover_image, created_at")
+        else
+          feeds = feeds.select("id, title_en AS title, content_en AS content, cover_image, created_at")
+        end
+        feeds.each {|feed| feed.content = feed.content.blank? ? "" : YAML.load(feed.content)}
+        @return_posts = Api::ApiHelper.reformat_feeds(feeds, root_url.chop, false)
       end
-      feeds.each {|feed| feed.content = feed.content.blank? ? "" : YAML.load(feed.content)}
-      @return_posts = Api::ApiHelper.reformat_feeds(feeds, root_url.chop, false)
     else
       @no_more = true
-      @return_posts = []
     end
     render json: Api::ApiHelper.json_response(@no_more, @return_posts), status: :ok
 

--- a/app/controllers/api/featured_posts_controller.rb
+++ b/app/controllers/api/featured_posts_controller.rb
@@ -19,4 +19,13 @@ class Api::FeaturedPostsController < Api::ApiBaseController
 
   end
 
+  def show
+    begin
+      post = FeaturePost.find(params[:id])
+      render json: {post: post}.to_json, status: :ok
+    rescue ActiveRecord::RecordNotFound => e
+      render json: {message: e.message}.to_json, status: :not_found
+    end
+  end
+
 end

--- a/app/controllers/api/featured_posts_controller.rb
+++ b/app/controllers/api/featured_posts_controller.rb
@@ -22,9 +22,9 @@ class Api::FeaturedPostsController < Api::ApiBaseController
   def show
     begin
       post = FeaturePost.find(params[:id])
-      render json: {post: post}.to_json, status: :ok
+      render json: { post: post }.to_json, status: :ok
     rescue ActiveRecord::RecordNotFound => e
-      render json: {message: e.message}.to_json, status: :not_found
+      render json: { message: e.message }.to_json, status: :not_found
     end
   end
 

--- a/app/controllers/api/featured_posts_controller.rb
+++ b/app/controllers/api/featured_posts_controller.rb
@@ -5,7 +5,6 @@ class Api::FeaturedPostsController < Api::ApiBaseController
 
     if params[:next_page].present?
       feeds = FeaturePost.paginate(:page => params[:next_page], :per_page => 6).latest
-      logger.debug "total: " + feeds.total_pages.to_s + " current: " + feeds.current_page.to_s
       @no_more = feeds.total_pages <= feeds.current_page
       unless feeds.blank?
         if @chinese

--- a/app/controllers/api/featured_posts_controller.rb
+++ b/app/controllers/api/featured_posts_controller.rb
@@ -1,0 +1,22 @@
+class Api::FeaturedPostsController < Api::ApiBaseController
+
+  def index
+    if params[:next_page].present?
+      feeds = FeaturePost.paginate(:page => params[:next_page], :per_page => 6).latest
+      @no_more = feeds.total_pages == feeds.current_page
+      if @chinese
+        feeds = feeds.select("id, title_cn AS title, content_cn AS content, cover_image, created_at")
+      else
+        feeds = feeds.select("id, title_en AS title, content_en AS content, cover_image, created_at")
+      end
+      feeds.each {|feed| feed.content = feed.content.blank? ? "" : YAML.load(feed.content)}
+      @return_posts = Api::ApiHelper.reformat_feeds(feeds, root_url.chop, false)
+    else
+      @no_more = true
+      @return_posts = []
+    end
+    render json: Api::ApiHelper.json_response(@no_more, @return_posts), status: :ok
+
+  end
+
+end

--- a/app/controllers/api/home_posts_controller.rb
+++ b/app/controllers/api/home_posts_controller.rb
@@ -9,18 +9,7 @@ class Api::HomePostsController < ApplicationController
       @no_more = page_index >= feeds.count
       feeds = feeds[page_index - 6.. page_index - 1]
       feeds.each do |feed|
-        case feed.class.name
-          when "FeaturePost"
-              feed.post_type = "features"
-          when "TrendPost"
-            feed.post_type = "trend"
-          when "OnCourtPost"
-              feed.post_type = "oncourt"
-          when "StreetSnapPost"
-            feed.post_type = "streetsnap"
-          when "RumorPost"
-            feed.post_type = "rumors"
-          end
+        feed = Api::ApiHelper.set_post_type(feed)
       end
       @return_posts = Api::ApiHelper.reformat(feeds, root_url.chop)
     else

--- a/app/controllers/api/home_posts_controller.rb
+++ b/app/controllers/api/home_posts_controller.rb
@@ -12,7 +12,7 @@ class Api::HomePostsController < Api::ApiBaseController
         feeds.each do |feed|
           feed = Api::ApiHelper.set_post_type(feed)
         end
-        @return_posts.concat(Api::ApiHelper.reformat_feeds(feeds, root_url.chop))
+        @return_posts.concat(Api::ApiHelper.reformat_feeds(feeds, root_url.chop, true))
         if params[:next_page].to_i == 1 # first request
           @slider_posts = Api::ApiHelper.get_slider_posts(@chinese, root_url.chop)
         end

--- a/app/controllers/api/home_posts_controller.rb
+++ b/app/controllers/api/home_posts_controller.rb
@@ -1,9 +1,8 @@
-class Api::HomePostsController < ApplicationController
+class Api::HomePostsController < Api::ApiBaseController
 
   def index
     if params[:next_page].present?
       logger.debug params[:l]
-      @chinese = params[:l] == 'cn';
       page_index = 6 * params[:next_page].to_i
       feeds = Post.get_posts(@chinese)
       @no_more = page_index >= feeds.count
@@ -11,7 +10,7 @@ class Api::HomePostsController < ApplicationController
       feeds.each do |feed|
         feed = Api::ApiHelper.set_post_type(feed)
       end
-      @return_posts = Api::ApiHelper.reformat(feeds, root_url.chop)
+      @return_posts = Api::ApiHelper.reformat_feeds(feeds, root_url.chop)
     else
       @no_more = true
       @return_posts = []

--- a/app/controllers/api/home_posts_controller.rb
+++ b/app/controllers/api/home_posts_controller.rb
@@ -1,8 +1,9 @@
 class Api::HomePostsController < Api::ApiBaseController
 
   def index
+    @return_posts = []
+    @slider_posts = []
     if params[:next_page].present?
-      logger.debug params[:l]
       page_index = 6 * params[:next_page].to_i
       feeds = Post.get_posts(@chinese)
       @no_more = page_index >= feeds.count
@@ -10,12 +11,14 @@ class Api::HomePostsController < Api::ApiBaseController
       feeds.each do |feed|
         feed = Api::ApiHelper.set_post_type(feed)
       end
-      @return_posts = Api::ApiHelper.reformat_feeds(feeds, root_url.chop)
+      @return_posts.concat(Api::ApiHelper.reformat_feeds(feeds, root_url.chop))
+      if params[:next_page].to_i == 1 # first request
+        @slider_posts = Api::ApiHelper.get_slider_posts(@chinese, root_url.chop)
+      end
     else
       @no_more = true
-      @return_posts = []
     end
-    render json: Api::ApiHelper.json_response(@no_more, @return_posts), status: :ok
+    render json: Api::ApiHelper.json_response(@no_more, @return_posts, @slider_posts), status: :ok
 
   end
 

--- a/app/controllers/api/home_posts_controller.rb
+++ b/app/controllers/api/home_posts_controller.rb
@@ -10,9 +10,6 @@ class Api::HomePostsController < Api::ApiBaseController
       @no_more = page_index >= feeds.count
       feeds = feeds[page_index - 6.. page_index - 1]
       unless feeds.blank?
-        feeds.each do |feed|
-          feed = Api::ApiHelper.set_post_type(feed)
-        end
         @return_posts.concat(Api::ApiHelper.reformat_feeds(feeds, root_url.chop, true))
         if params[:next_page].to_i == 1 # first request
           @slider_posts = Api::ApiHelper.get_slider_posts(@chinese, root_url.chop)

--- a/app/controllers/api/home_posts_controller.rb
+++ b/app/controllers/api/home_posts_controller.rb
@@ -3,6 +3,7 @@ class Api::HomePostsController < Api::ApiBaseController
   def index
     @return_posts = []
     @slider_posts = []
+
     if params[:next_page].present?
       page_index = 6 * params[:next_page].to_i
       feeds = Post.get_posts(@chinese)
@@ -20,8 +21,8 @@ class Api::HomePostsController < Api::ApiBaseController
     else
       @no_more = true
     end
-    render json: Api::ApiHelper.json_response(@no_more, @return_posts, @slider_posts), status: :ok
 
+    render json: Api::ApiHelper.json_response(@no_more, @return_posts, @slider_posts), status: :ok
   end
 
 end

--- a/app/controllers/api/home_posts_controller.rb
+++ b/app/controllers/api/home_posts_controller.rb
@@ -1,0 +1,34 @@
+class Api::HomePostsController < ApplicationController
+
+  def index
+    if params[:next_page].present?
+      logger.debug params[:l]
+      @chinese = params[:l] == 'cn';
+      page_index = 6 * params[:next_page].to_i
+      feeds = Post.get_posts(@chinese)
+      @no_more = page_index >= feeds.count
+      feeds = feeds[page_index - 6.. page_index - 1]
+      feeds.each do |feed|
+        case feed.class.name
+          when "FeaturePost"
+              feed.post_type = "features"
+          when "TrendPost"
+            feed.post_type = "trend"
+          when "OnCourtPost"
+              feed.post_type = "oncourt"
+          when "StreetSnapPost"
+            feed.post_type = "streetsnap"
+          when "RumorPost"
+            feed.post_type = "rumors"
+          end
+      end
+      @return_posts = Api::ApiHelper.reformat(feeds, root_url.chop)
+    else
+      @no_more = true
+      @return_posts = []
+    end
+    render json: Api::ApiHelper.json_response(@no_more, @return_posts), status: :ok
+
+  end
+
+end

--- a/app/controllers/api/home_posts_controller.rb
+++ b/app/controllers/api/home_posts_controller.rb
@@ -8,12 +8,14 @@ class Api::HomePostsController < Api::ApiBaseController
       feeds = Post.get_posts(@chinese)
       @no_more = page_index >= feeds.count
       feeds = feeds[page_index - 6.. page_index - 1]
-      feeds.each do |feed|
-        feed = Api::ApiHelper.set_post_type(feed)
-      end
-      @return_posts.concat(Api::ApiHelper.reformat_feeds(feeds, root_url.chop))
-      if params[:next_page].to_i == 1 # first request
-        @slider_posts = Api::ApiHelper.get_slider_posts(@chinese, root_url.chop)
+      unless feeds.blank?
+        feeds.each do |feed|
+          feed = Api::ApiHelper.set_post_type(feed)
+        end
+        @return_posts.concat(Api::ApiHelper.reformat_feeds(feeds, root_url.chop))
+        if params[:next_page].to_i == 1 # first request
+          @slider_posts = Api::ApiHelper.get_slider_posts(@chinese, root_url.chop)
+        end
       end
     else
       @no_more = true

--- a/app/controllers/api/oncourt_posts_controller.rb
+++ b/app/controllers/api/oncourt_posts_controller.rb
@@ -7,9 +7,9 @@ class Api::OncourtPostsController < Api::ApiBaseController
       @no_more = feeds.total_pages <= feeds.current_page
       unless feeds.blank?
         if @chinese
-          feeds = feeds.select("id, title_cn AS title, player_name_cn AS player_name, content_cn AS content, cover_image, created_at")
+          feeds = feeds.select("id, title_cn AS title, player_name_cn AS player_name, content_cn AS content, cover_image, created_at, author_id")
         else
-          feeds = feeds.select("id, title_en AS title, player_name_en AS player_name, content_en AS content, cover_image, created_at")
+          feeds = feeds.select("id, title_en AS title, player_name_en AS player_name, content_en AS content, cover_image, created_at, author_id")
         end
         feeds.each {|feed| feed.content = feed.content.blank? ? "" : YAML.load(feed.content)}
         @return_posts = Api::ApiHelper.reformat_feeds(feeds, root_url.chop)

--- a/app/controllers/api/oncourt_posts_controller.rb
+++ b/app/controllers/api/oncourt_posts_controller.rb
@@ -19,4 +19,13 @@ class Api::OncourtPostsController < Api::ApiBaseController
 
   end
 
+  def show
+    begin
+      post = OnCourtPost.find(params[:id])
+      render json: { post: post }.to_json, status: :ok
+    rescue ActiveRecord::RecordNotFound => e
+      render json: { message: e.message }.to_json, status: :not_found
+    end
+  end
+
 end

--- a/app/controllers/api/oncourt_posts_controller.rb
+++ b/app/controllers/api/oncourt_posts_controller.rb
@@ -1,0 +1,22 @@
+class Api::OncourtPostsController < Api::ApiBaseController
+
+  def index
+    if params[:next_page].present?
+      feeds = OnCourtPost.paginate(:page => params[:next_page], :per_page => 6).latest
+      @no_more = feeds.total_pages == feeds.current_page
+      if @chinese
+        feeds = feeds.select("id, title_cn AS title, player_name_cn AS player_name, content_cn AS content, cover_image, created_at")
+      else
+        feeds = feeds.select("id, title_en AS title, player_name_en AS player_name, content_en AS content, cover_image, created_at")
+      end
+      feeds.each {|feed| feed.content = feed.content.blank? ? "" : YAML.load(feed.content)}
+      @return_posts = Api::ApiHelper.reformat_feeds(feeds, root_url.chop, false)
+    else
+      @no_more = true
+      @return_posts = []
+    end
+    render json: Api::ApiHelper.json_response(@no_more, @return_posts), status: :ok
+
+  end
+
+end

--- a/app/controllers/api/oncourt_posts_controller.rb
+++ b/app/controllers/api/oncourt_posts_controller.rb
@@ -12,7 +12,7 @@ class Api::OncourtPostsController < Api::ApiBaseController
           feeds = feeds.select("id, title_en AS title, player_name_en AS player_name, content_en AS content, cover_image, created_at")
         end
         feeds.each {|feed| feed.content = feed.content.blank? ? "" : YAML.load(feed.content)}
-        @return_posts = Api::ApiHelper.reformat_feeds(feeds, root_url.chop, false)
+        @return_posts = Api::ApiHelper.reformat_feeds(feeds, root_url.chop)
       end
     else
       @no_more = true

--- a/app/controllers/api/oncourt_posts_controller.rb
+++ b/app/controllers/api/oncourt_posts_controller.rb
@@ -1,19 +1,21 @@
 class Api::OncourtPostsController < Api::ApiBaseController
 
   def index
+    @return_posts = []
     if params[:next_page].present?
       feeds = OnCourtPost.paginate(:page => params[:next_page], :per_page => 6).latest
-      @no_more = feeds.total_pages == feeds.current_page
-      if @chinese
-        feeds = feeds.select("id, title_cn AS title, player_name_cn AS player_name, content_cn AS content, cover_image, created_at")
-      else
-        feeds = feeds.select("id, title_en AS title, player_name_en AS player_name, content_en AS content, cover_image, created_at")
+      @no_more = feeds.total_pages <= feeds.current_page
+      unless feeds.blank?
+        if @chinese
+          feeds = feeds.select("id, title_cn AS title, player_name_cn AS player_name, content_cn AS content, cover_image, created_at")
+        else
+          feeds = feeds.select("id, title_en AS title, player_name_en AS player_name, content_en AS content, cover_image, created_at")
+        end
+        feeds.each {|feed| feed.content = feed.content.blank? ? "" : YAML.load(feed.content)}
+        @return_posts = Api::ApiHelper.reformat_feeds(feeds, root_url.chop, false)
       end
-      feeds.each {|feed| feed.content = feed.content.blank? ? "" : YAML.load(feed.content)}
-      @return_posts = Api::ApiHelper.reformat_feeds(feeds, root_url.chop, false)
     else
       @no_more = true
-      @return_posts = []
     end
     render json: Api::ApiHelper.json_response(@no_more, @return_posts), status: :ok
 

--- a/app/controllers/api/oncourt_posts_controller.rb
+++ b/app/controllers/api/oncourt_posts_controller.rb
@@ -22,7 +22,8 @@ class Api::OncourtPostsController < Api::ApiBaseController
   def show
     begin
       post = OnCourtPost.find(params[:id])
-      render json: { post: post }.to_json, status: :ok
+      return_post = Api::ApiHelper.format_post(post, root_url.chop)
+      render json: return_post.to_json, status: :ok
     rescue ActiveRecord::RecordNotFound => e
       render json: { message: e.message }.to_json, status: :not_found
     end

--- a/app/controllers/api/oncourt_posts_controller.rb
+++ b/app/controllers/api/oncourt_posts_controller.rb
@@ -2,6 +2,7 @@ class Api::OncourtPostsController < Api::ApiBaseController
 
   def index
     @return_posts = []
+    
     if params[:next_page].present?
       feeds = OnCourtPost.paginate(:page => params[:next_page], :per_page => 6).latest
       @no_more = feeds.total_pages <= feeds.current_page
@@ -17,8 +18,8 @@ class Api::OncourtPostsController < Api::ApiBaseController
     else
       @no_more = true
     end
-    render json: Api::ApiHelper.json_response(@no_more, @return_posts), status: :ok
 
+    render json: Api::ApiHelper.json_response(@no_more, @return_posts), status: :ok
   end
 
   def show

--- a/app/controllers/api/rumor_posts_controller.rb
+++ b/app/controllers/api/rumor_posts_controller.rb
@@ -7,9 +7,9 @@ class Api::RumorPostsController < Api::ApiBaseController
       @no_more = feeds.total_pages <= feeds.current_page
       unless feeds.blank?
         if @chinese
-          feeds = feeds.select("id, title_cn AS title, content_cn AS content, cover_image, created_at")
+          feeds = feeds.select("id, title_cn AS title, content_cn AS content, cover_image, created_at, author_id")
         else
-          feeds = feeds.select("id, title_en AS title, content_en AS content, cover_image, created_at")
+          feeds = feeds.select("id, title_en AS title, content_en AS content, cover_image, created_at, author_id")
         end
         feeds.each {|feed| feed.content = feed.content.blank? ? "" : YAML.load(feed.content)}
         @return_posts = Api::ApiHelper.reformat_feeds(feeds, root_url.chop)

--- a/app/controllers/api/rumor_posts_controller.rb
+++ b/app/controllers/api/rumor_posts_controller.rb
@@ -12,7 +12,7 @@ class Api::RumorPostsController < Api::ApiBaseController
           feeds = feeds.select("id, title_en AS title, content_en AS content, cover_image, created_at")
         end
         feeds.each {|feed| feed.content = feed.content.blank? ? "" : YAML.load(feed.content)}
-        @return_posts = Api::ApiHelper.reformat_feeds(feeds, root_url.chop, false)
+        @return_posts = Api::ApiHelper.reformat_feeds(feeds, root_url.chop)
       end
     else
       @no_more = true

--- a/app/controllers/api/rumor_posts_controller.rb
+++ b/app/controllers/api/rumor_posts_controller.rb
@@ -19,4 +19,13 @@ class Api::RumorPostsController < Api::ApiBaseController
 
   end
 
+  def show
+    begin
+      post = RumorPost.find(params[:id])
+      render json: { post: post }.to_json, status: :ok
+    rescue ActiveRecord::RecordNotFound => e
+      render json: { message: e.message }.to_json, status: :not_found
+    end
+  end
+
 end

--- a/app/controllers/api/rumor_posts_controller.rb
+++ b/app/controllers/api/rumor_posts_controller.rb
@@ -22,7 +22,8 @@ class Api::RumorPostsController < Api::ApiBaseController
   def show
     begin
       post = RumorPost.find(params[:id])
-      render json: { post: post }.to_json, status: :ok
+      return_post = Api::ApiHelper.format_post(post, root_url.chop)
+      render json: return_post.to_json, status: :ok
     rescue ActiveRecord::RecordNotFound => e
       render json: { message: e.message }.to_json, status: :not_found
     end

--- a/app/controllers/api/rumor_posts_controller.rb
+++ b/app/controllers/api/rumor_posts_controller.rb
@@ -2,6 +2,7 @@ class Api::RumorPostsController < Api::ApiBaseController
 
   def index
     @return_posts = []
+
     if params[:next_page].present?
       feeds = RumorPost.paginate(:page => params[:next_page], :per_page => 6).latest
       @no_more = feeds.total_pages <= feeds.current_page
@@ -17,8 +18,8 @@ class Api::RumorPostsController < Api::ApiBaseController
     else
       @no_more = true
     end
-    render json: Api::ApiHelper.json_response(@no_more, @return_posts), status: :ok
 
+    render json: Api::ApiHelper.json_response(@no_more, @return_posts), status: :ok
   end
 
   def show

--- a/app/controllers/api/rumor_posts_controller.rb
+++ b/app/controllers/api/rumor_posts_controller.rb
@@ -1,0 +1,22 @@
+class Api::RumorPostsController < Api::ApiBaseController
+
+  def index
+    if params[:next_page].present?
+      feeds = RumorPost.paginate(:page => params[:next_page], :per_page => 6).latest
+      @no_more = feeds.total_pages == feeds.current_page
+      if @chinese
+        feeds = feeds.select("id, title_cn AS title, content_cn AS content, cover_image, created_at")
+      else
+        feeds = feeds.select("id, title_en AS title, content_en AS content, cover_image, created_at")
+      end
+      feeds.each {|feed| feed.content = feed.content.blank? ? "" : YAML.load(feed.content)}
+      @return_posts = Api::ApiHelper.reformat_feeds(feeds, root_url.chop, false)
+    else
+      @no_more = true
+      @return_posts = []
+    end
+    render json: Api::ApiHelper.json_response(@no_more, @return_posts), status: :ok
+
+  end
+
+end

--- a/app/controllers/api/rumor_posts_controller.rb
+++ b/app/controllers/api/rumor_posts_controller.rb
@@ -1,19 +1,21 @@
 class Api::RumorPostsController < Api::ApiBaseController
 
   def index
+    @return_posts = []
     if params[:next_page].present?
       feeds = RumorPost.paginate(:page => params[:next_page], :per_page => 6).latest
-      @no_more = feeds.total_pages == feeds.current_page
-      if @chinese
-        feeds = feeds.select("id, title_cn AS title, content_cn AS content, cover_image, created_at")
-      else
-        feeds = feeds.select("id, title_en AS title, content_en AS content, cover_image, created_at")
+      @no_more = feeds.total_pages <= feeds.current_page
+      unless feeds.blank?
+        if @chinese
+          feeds = feeds.select("id, title_cn AS title, content_cn AS content, cover_image, created_at")
+        else
+          feeds = feeds.select("id, title_en AS title, content_en AS content, cover_image, created_at")
+        end
+        feeds.each {|feed| feed.content = feed.content.blank? ? "" : YAML.load(feed.content)}
+        @return_posts = Api::ApiHelper.reformat_feeds(feeds, root_url.chop, false)
       end
-      feeds.each {|feed| feed.content = feed.content.blank? ? "" : YAML.load(feed.content)}
-      @return_posts = Api::ApiHelper.reformat_feeds(feeds, root_url.chop, false)
     else
       @no_more = true
-      @return_posts = []
     end
     render json: Api::ApiHelper.json_response(@no_more, @return_posts), status: :ok
 

--- a/app/controllers/api/streetsnap_posts_controller.rb
+++ b/app/controllers/api/streetsnap_posts_controller.rb
@@ -7,9 +7,9 @@ class Api::StreetsnapPostsController < Api::ApiBaseController
       @no_more = feeds.total_pages <= feeds.current_page
       unless feeds.blank?
         if @chinese
-          feeds = feeds.select("id, title_cn AS title, content_cn AS content, cover_image, created_at")
+          feeds = feeds.select("id, title_cn AS title, content_cn AS content, cover_image, created_at, author_id")
         else
-          feeds = feeds.select("id, title_en AS title, content_en AS content, cover_image, created_at")
+          feeds = feeds.select("id, title_en AS title, content_en AS content, cover_image, created_at, author_id")
         end
         feeds.each {|feed| feed.content = feed.content.blank? ? "" : YAML.load(feed.content)}
         @return_posts = Api::ApiHelper.reformat_feeds(feeds, root_url.chop)

--- a/app/controllers/api/streetsnap_posts_controller.rb
+++ b/app/controllers/api/streetsnap_posts_controller.rb
@@ -1,19 +1,21 @@
 class Api::StreetsnapPostsController < Api::ApiBaseController
 
   def index
+    @return_posts = []
     if params[:next_page].present?
       feeds = StreetSnapPost.paginate(:page => params[:next_page], :per_page => 6).latest
-      @no_more = feeds.total_pages == feeds.current_page
-      if @chinese
-        feeds = feeds.select("id, title_cn AS title, content_cn AS content, cover_image, created_at")
-      else
-        feeds = feeds.select("id, title_en AS title, content_en AS content, cover_image, created_at")
+      @no_more = feeds.total_pages <= feeds.current_page
+      unless feeds.blank?
+        if @chinese
+          feeds = feeds.select("id, title_cn AS title, content_cn AS content, cover_image, created_at")
+        else
+          feeds = feeds.select("id, title_en AS title, content_en AS content, cover_image, created_at")
+        end
+        feeds.each {|feed| feed.content = feed.content.blank? ? "" : YAML.load(feed.content)}
+        @return_posts = Api::ApiHelper.reformat_feeds(feeds, root_url.chop, false)
       end
-      feeds.each {|feed| feed.content = feed.content.blank? ? "" : YAML.load(feed.content)}
-      @return_posts = Api::ApiHelper.reformat_feeds(feeds, root_url.chop, false)
     else
       @no_more = true
-      @return_posts = []
     end
     render json: Api::ApiHelper.json_response(@no_more, @return_posts), status: :ok
 

--- a/app/controllers/api/streetsnap_posts_controller.rb
+++ b/app/controllers/api/streetsnap_posts_controller.rb
@@ -22,7 +22,8 @@ class Api::StreetsnapPostsController < Api::ApiBaseController
   def show
     begin
       post = StreetSnapPost.find(params[:id])
-      render json: { post: post }.to_json, status: :ok
+      return_post = Api::ApiHelper.format_post(post, root_url.chop)
+      render json: return_post.to_json, status: :ok
     rescue ActiveRecord::RecordNotFound => e
       render json: { message: e.message }.to_json, status: :not_found
     end

--- a/app/controllers/api/streetsnap_posts_controller.rb
+++ b/app/controllers/api/streetsnap_posts_controller.rb
@@ -2,6 +2,7 @@ class Api::StreetsnapPostsController < Api::ApiBaseController
 
   def index
     @return_posts = []
+
     if params[:next_page].present?
       feeds = StreetSnapPost.paginate(:page => params[:next_page], :per_page => 6).latest
       @no_more = feeds.total_pages <= feeds.current_page
@@ -17,8 +18,8 @@ class Api::StreetsnapPostsController < Api::ApiBaseController
     else
       @no_more = true
     end
-    render json: Api::ApiHelper.json_response(@no_more, @return_posts), status: :ok
 
+    render json: Api::ApiHelper.json_response(@no_more, @return_posts), status: :ok
   end
 
   def show

--- a/app/controllers/api/streetsnap_posts_controller.rb
+++ b/app/controllers/api/streetsnap_posts_controller.rb
@@ -12,7 +12,7 @@ class Api::StreetsnapPostsController < Api::ApiBaseController
           feeds = feeds.select("id, title_en AS title, content_en AS content, cover_image, created_at")
         end
         feeds.each {|feed| feed.content = feed.content.blank? ? "" : YAML.load(feed.content)}
-        @return_posts = Api::ApiHelper.reformat_feeds(feeds, root_url.chop, false)
+        @return_posts = Api::ApiHelper.reformat_feeds(feeds, root_url.chop)
       end
     else
       @no_more = true

--- a/app/controllers/api/streetsnap_posts_controller.rb
+++ b/app/controllers/api/streetsnap_posts_controller.rb
@@ -1,0 +1,22 @@
+class Api::StreetsnapPostsController < Api::ApiBaseController
+
+  def index
+    if params[:next_page].present?
+      feeds = StreetSnapPost.paginate(:page => params[:next_page], :per_page => 6).latest
+      @no_more = feeds.total_pages == feeds.current_page
+      if @chinese
+        feeds = feeds.select("id, title_cn AS title, content_cn AS content, cover_image, created_at")
+      else
+        feeds = feeds.select("id, title_en AS title, content_en AS content, cover_image, created_at")
+      end
+      feeds.each {|feed| feed.content = feed.content.blank? ? "" : YAML.load(feed.content)}
+      @return_posts = Api::ApiHelper.reformat_feeds(feeds, root_url.chop, false)
+    else
+      @no_more = true
+      @return_posts = []
+    end
+    render json: Api::ApiHelper.json_response(@no_more, @return_posts), status: :ok
+
+  end
+
+end

--- a/app/controllers/api/streetsnap_posts_controller.rb
+++ b/app/controllers/api/streetsnap_posts_controller.rb
@@ -19,4 +19,13 @@ class Api::StreetsnapPostsController < Api::ApiBaseController
 
   end
 
+  def show
+    begin
+      post = StreetSnapPost.find(params[:id])
+      render json: { post: post }.to_json, status: :ok
+    rescue ActiveRecord::RecordNotFound => e
+      render json: { message: e.message }.to_json, status: :not_found
+    end
+  end
+
 end

--- a/app/controllers/api/trend_posts_controller.rb
+++ b/app/controllers/api/trend_posts_controller.rb
@@ -11,7 +11,7 @@ class Api::TrendPostsController < Api::ApiBaseController
         else
           feeds = feeds.select("id, title_en AS title, cover_image, created_at")
         end
-        @return_posts = Api::ApiHelper.reformat_feeds(feeds, root_url.chop, false)
+        @return_posts = Api::ApiHelper.reformat_feeds(feeds, root_url.chop)
       end
     else
       @no_more = true

--- a/app/controllers/api/trend_posts_controller.rb
+++ b/app/controllers/api/trend_posts_controller.rb
@@ -1,18 +1,20 @@
 class Api::TrendPostsController < Api::ApiBaseController
 
   def index
+    @return_posts = []
     if params[:next_page].present?
       feeds = TrendPost.paginate(:page => params[:next_page], :per_page => 6).latest
-      @no_more = feeds.total_pages == feeds.current_page
-      if @chinese
-				feeds = feeds.select("id, title_cn AS title, cover_image, created_at")
-			else
-				feeds = feeds.select("id, title_en AS title, cover_image, created_at")
-			end
-      @return_posts = Api::ApiHelper.reformat_feeds(feeds, root_url.chop, false)
+      @no_more = feeds.total_pages <= feeds.current_page
+      unless feeds.blank?
+        if @chinese
+          feeds = feeds.select("id, title_cn AS title, cover_image, created_at")
+        else
+          feeds = feeds.select("id, title_en AS title, cover_image, created_at")
+        end
+        @return_posts = Api::ApiHelper.reformat_feeds(feeds, root_url.chop, false)
+      end
     else
       @no_more = true
-      @return_posts = []
     end
     render json: Api::ApiHelper.json_response(@no_more, @return_posts), status: :ok
 

--- a/app/controllers/api/trend_posts_controller.rb
+++ b/app/controllers/api/trend_posts_controller.rb
@@ -21,7 +21,8 @@ class Api::TrendPostsController < Api::ApiBaseController
   def show
     begin
       post = TrendPost.find(params[:id])
-      render json: { post: post }.to_json, status: :ok
+      return_post = Api::ApiHelper.format_post(post, root_url.chop)
+      render json: return_post.to_json, status: :ok
     rescue ActiveRecord::RecordNotFound => e
       render json: { message: e.message }.to_json, status: :not_found
     end

--- a/app/controllers/api/trend_posts_controller.rb
+++ b/app/controllers/api/trend_posts_controller.rb
@@ -1,0 +1,21 @@
+class Api::TrendPostsController < Api::ApiBaseController
+
+  def index
+    if params[:next_page].present?
+      feeds = TrendPost.paginate(:page => params[:next_page], :per_page => 6).latest
+      @no_more = feeds.total_pages == feeds.current_page
+      if @chinese
+				feeds = feeds.select("id, title_cn AS title, cover_image, created_at")
+			else
+				feeds = feeds.select("id, title_en AS title, cover_image, created_at")
+			end
+      @return_posts = Api::ApiHelper.reformat_feeds(feeds, root_url.chop, false)
+    else
+      @no_more = true
+      @return_posts = []
+    end
+    render json: Api::ApiHelper.json_response(@no_more, @return_posts), status: :ok
+
+  end
+
+end

--- a/app/controllers/api/trend_posts_controller.rb
+++ b/app/controllers/api/trend_posts_controller.rb
@@ -7,9 +7,9 @@ class Api::TrendPostsController < Api::ApiBaseController
       @no_more = feeds.total_pages <= feeds.current_page
       unless feeds.blank?
         if @chinese
-          feeds = feeds.select("id, title_cn AS title, cover_image, created_at")
+          feeds = feeds.select("id, title_cn AS title, cover_image, created_at, author_id")
         else
-          feeds = feeds.select("id, title_en AS title, cover_image, created_at")
+          feeds = feeds.select("id, title_en AS title, cover_image, created_at, author_id")
         end
         @return_posts = Api::ApiHelper.reformat_feeds(feeds, root_url.chop)
       end

--- a/app/controllers/api/trend_posts_controller.rb
+++ b/app/controllers/api/trend_posts_controller.rb
@@ -18,4 +18,13 @@ class Api::TrendPostsController < Api::ApiBaseController
 
   end
 
+  def show
+    begin
+      post = TrendPost.find(params[:id])
+      render json: { post: post }.to_json, status: :ok
+    rescue ActiveRecord::RecordNotFound => e
+      render json: { message: e.message }.to_json, status: :not_found
+    end
+  end
+
 end

--- a/app/controllers/api/trend_posts_controller.rb
+++ b/app/controllers/api/trend_posts_controller.rb
@@ -2,6 +2,7 @@ class Api::TrendPostsController < Api::ApiBaseController
 
   def index
     @return_posts = []
+
     if params[:next_page].present?
       feeds = TrendPost.paginate(:page => params[:next_page], :per_page => 6).latest
       @no_more = feeds.total_pages <= feeds.current_page
@@ -16,8 +17,8 @@ class Api::TrendPostsController < Api::ApiBaseController
     else
       @no_more = true
     end
-    render json: Api::ApiHelper.json_response(@no_more, @return_posts), status: :ok
 
+    render json: Api::ApiHelper.json_response(@no_more, @return_posts), status: :ok
   end
 
   def show

--- a/app/helpers/api/api_helper.rb
+++ b/app/helpers/api/api_helper.rb
@@ -14,8 +14,25 @@ module Api::ApiHelper
     return @return_posts
   end
 
-  def self.json_response(no_more, posts)
-    return {:no_more => no_more, :posts => posts}.to_json
+  def self.get_slider_posts(chinese, root_url)
+    if chinese
+      posts = Post.posts.select("id, title_cn AS title, image, created_at, pointer_type, pointer_id, post_type")
+    else
+      posts = Post.posts.select("id, title_en AS title, image, created_at, pointer_type, pointer_id, post_type")
+    end
+    @slider_posts = []
+    posts.each do |post|
+      full_img_url = root_url + post.image.url
+      slider_post = { post: post, image_url: full_img_url }
+      @slider_posts.push(slider_post)
+    end
+    return @slider_posts
+  end
+
+  def self.json_response(no_more, posts, slider_posts=[])
+    response = {:no_more => no_more, :posts => posts}
+    response[:slider_posts] = slider_posts unless slider_posts.empty?
+    return response.to_json
   end
 
   def self.set_post_type(post)

--- a/app/helpers/api/api_helper.rb
+++ b/app/helpers/api/api_helper.rb
@@ -2,18 +2,34 @@ module Api::ApiHelper
 
   def self.reformat(original_feeds, root_url)
     @return_posts = []
-		original_feeds.each do |post|
+    original_feeds.each do |post|
       full_img_url = root_url + post.cover_image.url
-			post_hash = {:post => post, :image_url => full_img_url}
-			post_hash[:score] = (post.rates.average(:score) || 0).round(1) if (defined? post.rates)
-			post_hash[:post_type] = post.post_type if (defined? post.post_type)
-			@return_posts.push(post_hash)
-		end
+      post_hash = {:post => post, :image_url => full_img_url}
+      post_hash[:score] = (post.rates.average(:score) || 0).round(1) if (defined? post.rates)
+      post_hash[:post_type] = post.post_type if (defined? post.post_type)
+      @return_posts.push(post_hash)
+    end
     return @return_posts
   end
 
   def self.json_response(no_more, posts)
     return {:no_more => no_more, :posts => posts}.to_json
+  end
+
+  def self.set_post_type(post)
+    case post.class.name
+    when "FeaturePost"
+      post.post_type = "features"
+    when "TrendPost"
+      post.post_type = "trend"
+    when "OnCourtPost"
+      post.post_type = "oncourt"
+    when "StreetSnapPost"
+      post.post_type = "streetsnap"
+    when "RumorPost"
+      post.post_type = "rumors"
+    end
+    return post
   end
 
 end

--- a/app/helpers/api/api_helper.rb
+++ b/app/helpers/api/api_helper.rb
@@ -28,7 +28,7 @@ module Api::ApiHelper
   def self.format_post(post, root_url)
     full_img_url = root_url + post.cover_image.url
     post_hash = {:post => post, :image_url => full_img_url}
-    post_hash[:score] = (post.rates.average(:score) || 0).round(1).to_i if (defined? post.rates)
+    post_hash[:score] = (post.rates.average(:score) || 0).round(1).to_f if (defined? post.rates)
     post_hash[:vote_count] = (defined? post.rates) ? post.rates.count : 0;
     if post.has_attribute?(:author_id)
       post_hash[:author_name] = post.author.username.empty? ? 'Kicks4Love' : post.author.username

--- a/app/helpers/api/api_helper.rb
+++ b/app/helpers/api/api_helper.rb
@@ -1,12 +1,14 @@
 module Api::ApiHelper
 
-  def self.reformat(original_feeds, root_url)
+  def self.reformat_feeds(original_feeds, root_url, is_index=true)
     @return_posts = []
     original_feeds.each do |post|
       full_img_url = root_url + post.cover_image.url
       post_hash = {:post => post, :image_url => full_img_url}
       post_hash[:score] = (post.rates.average(:score) || 0).round(1) if (defined? post.rates)
-      post_hash[:post_type] = post.post_type if (defined? post.post_type)
+      if is_index
+        post_hash[:post_type] = post.post_type if (defined? post.post_type)
+      end
       @return_posts.push(post_hash)
     end
     return @return_posts

--- a/app/helpers/api/api_helper.rb
+++ b/app/helpers/api/api_helper.rb
@@ -28,7 +28,11 @@ module Api::ApiHelper
   def self.format_post(post, root_url)
     full_img_url = root_url + post.cover_image.url
     post_hash = {:post => post, :image_url => full_img_url}
-    post_hash[:score] = (post.rates.average(:score) || 0).round(1) if (defined? post.rates)
+    post_hash[:score] = (post.rates.average(:score) || 0).round(1).to_i if (defined? post.rates)
+    post_hash[:vote_count] = (defined? post.rates) ? post.rates.count : 0;
+    if post.has_attribute?(:author_id)
+      post_hash[:author_name] = post.author.username.empty? ? 'Kicks4Love' : post.author.username
+    end
     unless !defined?(post.main_images) || post.main_images.blank?
       full_imgs = []
       post.main_images.each do |image|

--- a/app/helpers/api/api_helper.rb
+++ b/app/helpers/api/api_helper.rb
@@ -5,7 +5,7 @@ module Api::ApiHelper
     original_feeds.each do |post|
       post_hash = format_post(post, root_url)
       if is_index
-        post_hash[:post_type] = post.post_type if (defined? post.post_type)
+        post_hash[:post_type] = post_to_type(post)
       end
       @return_posts.push(post_hash)
     end
@@ -14,12 +14,10 @@ module Api::ApiHelper
 
   def self.reformat_search_results(original_results, root_url)
     return [] if original_results.blank?
-
     results = []
     original_results.each do |result|
-      result_hash = format_post(result._source, root_url)
-      result_hash[:post_type] = result._type
-      result_hash[:score] = result._score
+      result_hash = format_post(result, root_url)
+      result_hash[:post_type] = post_to_type(result)
       results.push(result_hash)
     end
     return results
@@ -65,20 +63,24 @@ module Api::ApiHelper
     return response.to_json
   end
 
-  def self.set_post_type(post)
+  def self.post_to_type(post)
     case post.class.name
     when "FeaturePost"
-      post.post_type = "features"
+      return "features"
     when "TrendPost"
-      post.post_type = "trend"
+      return "trend"
     when "OnCourtPost"
-      post.post_type = "oncourt"
+      return "oncourt"
     when "StreetSnapPost"
-      post.post_type = "streetsnap"
+      return "streetsnap"
     when "RumorPost"
-      post.post_type = "rumors"
+      return "rumors"
+    when "CalendarPost"
+      return "calendar"
+    else
+      return "post"
     end
-    return post
+
   end
 
 end

--- a/app/helpers/api/api_helper.rb
+++ b/app/helpers/api/api_helper.rb
@@ -80,7 +80,6 @@ module Api::ApiHelper
     else
       return "post"
     end
-
   end
 
 end

--- a/app/helpers/api/api_helper.rb
+++ b/app/helpers/api/api_helper.rb
@@ -12,6 +12,19 @@ module Api::ApiHelper
     return @return_posts
   end
 
+  def self.reformat_search_results(original_results, root_url)
+    return [] if original_results.blank?
+
+    results = []
+    original_results.each do |result|
+      result_hash = format_post(result._source, root_url)
+      result_hash[:post_type] = result._type
+      result_hash[:score] = result._score
+      results.push(result_hash)
+    end
+    return results
+  end
+
   def self.format_post(post, root_url)
     full_img_url = root_url + post.cover_image.url
     post_hash = {:post => post, :image_url => full_img_url}

--- a/app/helpers/api/api_helper.rb
+++ b/app/helpers/api/api_helper.rb
@@ -12,12 +12,14 @@ module Api::ApiHelper
     return @return_posts
   end
 
-  def self.reformat_search_results(original_results, root_url)
+  def self.reformat_search_results(chinese, original_results, root_url)
     return [] if original_results.blank?
     results = []
     original_results.each do |result|
       result_hash = format_post(result, root_url)
       result_hash[:post_type] = post_to_type(result)
+      result_hash[:content] = chinese ? result_hash[:post][:content_cn] : result_hash[:post][:content_en]
+      result_hash[:title] = chinese ? result_hash[:post][:title_cn] : result_hash[:post][:title_en]
       results.push(result_hash)
     end
     return results

--- a/app/helpers/api/api_helper.rb
+++ b/app/helpers/api/api_helper.rb
@@ -1,6 +1,6 @@
 module Api::ApiHelper
 
-  def self.reformat_feeds(original_feeds, root_url, is_index=true)
+  def self.reformat_feeds(original_feeds, root_url, is_index=false)
     @return_posts = []
     original_feeds.each do |post|
       post_hash = format_post(post, root_url)
@@ -16,7 +16,7 @@ module Api::ApiHelper
     full_img_url = root_url + post.cover_image.url
     post_hash = {:post => post, :image_url => full_img_url}
     post_hash[:score] = (post.rates.average(:score) || 0).round(1) if (defined? post.rates)
-    unless post.main_images.blank?
+    unless !defined?(post.main_images) || post.main_images.blank?
       full_imgs = []
       post.main_images.each do |image|
         full_img_url = root_url + image.url

--- a/app/helpers/api/api_helper.rb
+++ b/app/helpers/api/api_helper.rb
@@ -3,15 +3,28 @@ module Api::ApiHelper
   def self.reformat_feeds(original_feeds, root_url, is_index=true)
     @return_posts = []
     original_feeds.each do |post|
-      full_img_url = root_url + post.cover_image.url
-      post_hash = {:post => post, :image_url => full_img_url}
-      post_hash[:score] = (post.rates.average(:score) || 0).round(1) if (defined? post.rates)
+      post_hash = format_post(post, root_url)
       if is_index
         post_hash[:post_type] = post.post_type if (defined? post.post_type)
       end
       @return_posts.push(post_hash)
     end
     return @return_posts
+  end
+
+  def self.format_post(post, root_url)
+    full_img_url = root_url + post.cover_image.url
+    post_hash = {:post => post, :image_url => full_img_url}
+    post_hash[:score] = (post.rates.average(:score) || 0).round(1) if (defined? post.rates)
+    unless post.main_images.blank?
+      full_imgs = []
+      post.main_images.each do |image|
+        full_img_url = root_url + image.url
+        full_imgs.push( { url: full_img_url } )
+      end
+      post_hash[:main_images] = full_imgs
+    end
+    return post_hash
   end
 
   def self.get_slider_posts(chinese, root_url)

--- a/app/helpers/api/api_helper.rb
+++ b/app/helpers/api/api_helper.rb
@@ -1,0 +1,19 @@
+module Api::ApiHelper
+
+  def self.reformat(original_feeds, root_url)
+    @return_posts = []
+		original_feeds.each do |post|
+      full_img_url = root_url + post.cover_image.url
+			post_hash = {:post => post, :image_url => full_img_url}
+			post_hash[:score] = (post.rates.average(:score) || 0).round(1) if (defined? post.rates)
+			post_hash[:post_type] = post.post_type if (defined? post.post_type)
+			@return_posts.push(post_hash)
+		end
+    return @return_posts
+  end
+
+  def self.json_response(no_more, posts)
+    return {:no_more => no_more, :posts => posts}.to_json
+  end
+
+end

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -2,6 +2,7 @@ class AdminUser < ApplicationRecord
 
   devise :database_authenticatable, :registerable, :rememberable, :trackable, :validatable
   validate :not_adding_root_user
+  has_one :api_key
 
   scope :non_root_users, -> {where("email NOT LIKE 'root%'")}
 

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -1,0 +1,13 @@
+class ApiKey < ApplicationRecord
+  belongs_to :admin_user
+  before_create :generate_access_token
+
+  private
+  
+  def generate_access_token
+    begin
+      self.access_token = SecureRandom.hex
+    end while self.class.exists?(access_token: access_token)
+  end
+
+end

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -1,13 +1,14 @@
 class ApiKey < ApplicationRecord
-  belongs_to :admin_user
-  before_create :generate_access_token
 
-  private
+  	belongs_to :admin_user
+  	before_create :generate_access_token
+
+  	private
   
-  def generate_access_token
-    begin
-      self.access_token = SecureRandom.hex
-    end while self.class.exists?(access_token: access_token)
-  end
+  	def generate_access_token
+    	begin
+      	self.access_token = SecureRandom.hex
+    	end while self.class.exists?(access_token: access_token)
+  	end
 
 end

--- a/app/views/admin/admin_users/show.html.erb
+++ b/app/views/admin/admin_users/show.html.erb
@@ -30,15 +30,19 @@
 <label>Last Update Time:</label>
 <p><%= @admin_user.updated_at.strftime("%Y-%m-%d %H:%M") %></p>
 
-<label>Api Key: </label>
-<p> <%= @api_key.access_token %> </p>
-
-<br/>
-
 <%
-	is_root_user = @admin_user.root_user?
-	is_same_user = @admin_user.email == current_admin_user.email
+is_root_user = @admin_user.root_user?
+current_is_root = current_admin_user.root_user?
+is_same_user = @admin_user.email == current_admin_user.email
 %>
+
+<label>Api Key: </label>
+<% if current_is_root || is_same_user %>
+<p> <%= @api_key %> </p>
+<% else %>
+<p> ***************** </p>
+<% end %>
+<br/>
 
 <% if is_same_user %>
 	<%= link_to "Edit", edit_admin_user_registration_path(@admin_user), :class => "btn btn-primary" %>

--- a/app/views/admin/admin_users/show.html.erb
+++ b/app/views/admin/admin_users/show.html.erb
@@ -30,6 +30,9 @@
 <label>Last Update Time:</label>
 <p><%= @admin_user.updated_at.strftime("%Y-%m-%d %H:%M") %></p>
 
+<label>Api Key: </label>
+<p> <%= @api_key.access_token %> </p>
+
 <br/>
 
 <%

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -40,6 +40,11 @@
       <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
       <%= f.password_field :current_password, autocomplete: "off" %>
     </div>
+    <div>
+      <% @api_text = resource.api_key.present? ? 'Reset your API key?' : 'Set API key?'%>
+      <label><%= @api_text %></label>
+  		<%= check_box_tag :set_api_key %>
+    </div>
 
     <br/>
 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -27,6 +27,11 @@
       <%= f.password_field :password_confirmation, autocomplete: "off" %>
     </div>
 
+    <div class="field">
+      <label>Set API key?</label>
+  		<%= check_box_tag :set_api_key %>
+    </div>
+
     <br/>
 
     <div class="actions">

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,5 +31,12 @@ module Kicks4love
         :error_notification => 'error@kicks4love.com',
         :customer_service => 'customerservice@kicks4love.com'
     }
+    config.middleware.insert_before 0, Rack::Cors do
+      allow do
+        origins '*'
+        resource '/api/v0', :headers => :any, :methods => [:get, :post]
+      end
+    end
+    
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -113,6 +113,9 @@ Rails.application.routes.draw do
         get '/' => 'rumor_posts#index'
         get '/:id' => 'rumor_posts#show'
       end
+      scope :calendar_posts do
+        get '/' => 'calendar_posts#index'
+      end
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -95,6 +95,23 @@ Rails.application.routes.draw do
       end
       scope :featured_posts do
         get '/' => 'featured_posts#index'
+        get '/:id' => 'featured_posts#show'
+      end
+      scope :oncourt_posts do
+        get '/' => 'oncourt_posts#index'
+        get '/:id' => 'oncourt_posts#show'
+      end
+      scope :trend_posts do
+        get '/' => 'trend_posts#index'
+        get '/:id' => 'trend_posts#show'
+      end
+      scope :streetsnap_posts do
+        get '/' => 'streetsnap_posts#index'
+        get '/:id' => 'streetsnap_posts#show'
+      end
+      scope :rumor_posts do
+        get '/' => 'rumor_posts#index'
+        get '/:id' => 'rumor_posts#show'
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -116,6 +116,7 @@ Rails.application.routes.draw do
       scope :calendar_posts do
         get '/' => 'calendar_posts#index'
       end
+      get '/search' => 'api_base#search'
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -117,6 +117,7 @@ Rails.application.routes.draw do
         get '/' => 'calendar_posts#index'
       end
       get '/search' => 'api_base#search'
+      post '/rate' => 'api_base#rate'
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -118,6 +118,7 @@ Rails.application.routes.draw do
       end
       get '/search' => 'api_base#search'
       post '/rate' => 'api_base#rate'
+      post '/email' => 'api_base#email'
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,4 +88,15 @@ Rails.application.routes.draw do
 
   get '/sitemap.xml', :to => 'sitemap#index', :defaults => {:format => 'xml'}
 
+  namespace :api do
+    scope :v0 do
+      scope :home_posts do
+        get '/' => 'home_posts#index'
+      end
+      scope :featured_posts do
+        get '/' => 'featured_posts#index'
+      end
+    end
+  end
+
 end

--- a/db/migrate/20170726154732_create_api_keys.rb
+++ b/db/migrate/20170726154732_create_api_keys.rb
@@ -1,0 +1,10 @@
+class CreateApiKeys < ActiveRecord::Migration[5.0]
+  def change
+    create_table :api_keys do |t|
+      t.string :access_token
+      t.references :admin_user, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/test/controllers/api/home_posts_controller_test.rb
+++ b/test/controllers/api/home_posts_controller_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class Api::HomePostsControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get api_home_posts_index_url
+    assert_response :success
+  end
+
+end


### PR DESCRIPTION
- get posts endpoints with `next_page` and `l`(language) query params for all post types
- show page endpoints for all post types except calendar posts

Todo:
- [x] search endpoint with keyword and maybe post type query
- [ ] Enable CORS settings if necessary
- [x] Auth restriction
- [x] rating endpoint? could just enable CORS on current method, or better yet, move it to the `/api/v0/` scope